### PR TITLE
From date to date_i18n for email template

### DIFF
--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -188,7 +188,7 @@ function pmproconpd_pmpro_email_body( $body, $email ) {
 		if ( ! empty( $user_id ) ) {
 			// Is the date in the future?
 			if ( $pmpro_next_payment_timestamp - current_time( 'timestamp' ) > 0 ) {
-				$expiry_date = date( get_option( 'date_format' ), $pmpro_next_payment_timestamp );
+				$expiry_date = date_i18n( get_option( 'date_format' ), $pmpro_next_payment_timestamp );
 				$body .= '<p>' . sprintf( __( 'Your access will expire on %s.', 'pmpro-cancel-on-next-payment-date' ), $expiry_date ) . '</p>';
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use standard `date_i18n` wp' function, when possible.
