### PR TITLE
Ensuring timestamps passed to date() are ints

### DIFF
--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -133,7 +133,7 @@ function pmproconpd_pmpro_change_level( $level, $user_id, $old_level_status, $ca
 	}
 
 	// Update the expiration date.
-	$expiration_date = date( 'Y-m-d H:i:s', $pmpro_next_payment_timestamp );
+	$expiration_date = date( 'Y-m-d H:i:s', intval( $pmpro_next_payment_timestamp ) );
 
 	$wpdb->update(
 		$wpdb->pmpro_memberships_users,
@@ -188,7 +188,7 @@ function pmproconpd_gettext_cancel_text( $translated_text, $text, $domain ) {
 		global $current_user;
 
 		// translators: %s: The date the subscription will expire on.
-		$translated_text = sprintf( __( 'Your recurring subscription has been cancelled. Your active membership will expire on %s.', 'pmpro-cancel-on-next-payment-date' ), date( get_option( 'date_format' ), $pmpro_next_payment_timestamp ) );
+		$translated_text = sprintf( __( 'Your recurring subscription has been cancelled. Your active membership will expire on %s.', 'pmpro-cancel-on-next-payment-date' ), date( get_option( 'date_format' ), intval( $pmpro_next_payment_timestamp ) ) );
 	}
 
 	return $translated_text;
@@ -236,7 +236,7 @@ function pmproconpd_pmpro_email_body( $body, $email ) {
 		return $body;
 	}
 
-	$expiry_date = date_i18n( get_option( 'date_format' ), $pmpro_next_payment_timestamp );
+	$expiry_date = date_i18n( get_option( 'date_format' ), intval( $pmpro_next_payment_timestamp ) );
 
 	// translators: %s: The date that access will expire on.
 	$body .= '<p>' . sprintf( __( 'Your access will expire on %s.', 'pmpro-cancel-on-next-payment-date' ), $expiry_date ) . '</p>';
@@ -282,10 +282,10 @@ function pmproconpd_pmpro_email_data( $data, $email ) {
 
 	// Set the !!startdate!! variable.
 	$membership_level = pmpro_getMembershipLevelForUser($user_id, true);
-	$data['startdate'] = date_i18n( get_option( 'date_format' ), $membership_level->startdate );
+	$data['startdate'] = date_i18n( get_option( 'date_format' ), intval( $membership_level->startdate ) );
 
 	// Set the !!enddate!! variable.
-	$data['enddate'] = date_i18n( get_option( 'date_format' ), $pmpro_next_payment_timestamp );
+	$data['enddate'] = date_i18n( get_option( 'date_format' ), intval( $pmpro_next_payment_timestamp ) );
 
 	return $data;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now ensuring that timestamps passed to date() and date_i18n() are integers.

Based off of this wp.org ticket: https://wordpress.org/support/topic/php-error-log-warning-date-expects-parameter-2-to-be-int/

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
