### PR TITLE
Internationalize date for cancellation text string.

### DIFF
--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -188,7 +188,7 @@ function pmproconpd_gettext_cancel_text( $translated_text, $text, $domain ) {
 		global $current_user;
 
 		// translators: %s: The date the subscription will expire on.
-		$translated_text = sprintf( __( 'Your recurring subscription has been cancelled. Your active membership will expire on %s.', 'pmpro-cancel-on-next-payment-date' ), date( get_option( 'date_format' ), $pmpro_next_payment_timestamp ) );
+		$translated_text = sprintf( __( 'Your recurring subscription has been cancelled. Your active membership will expire on %s.', 'pmpro-cancel-on-next-payment-date' ), date_i18n( get_option( 'date_format' ), $pmpro_next_payment_timestamp ) );
 	}
 
 	return $translated_text;


### PR DESCRIPTION
Internationalize date for the cancellation text string.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/issues/28

### How to test the changes in this Pull Request:

1. Go to Settings > General and set the Site Language option to Deutsch and save settings.
2. In a private/incognito browser window log in as a user that is subscribed to a recurring membership level.
3. Navigate to the Membership Account page and click on the link to cancel the membership subscription.
4. Confirm cancellation.
5. Observe that the date is displayed in the language set in the site language option instead of English.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX/ENHANCEMENT: Now localizing the end date that is in confirmation messages.
