### PR TITLE
Fix bracket and bail in an additional case

### DIFF
--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -48,7 +48,8 @@ function pmproconpd_pmpro_change_level( $level, $user_id, $old_level_status, $ca
 
 	// Bypass if not on cancellation page or a non-profile admin page.
 	// Webhook IPN calls that go through admin-ajax are non-profile admin pages.
-	if ( ! $is_on_cancel_page && ( ! is_admin() || $is_on_profile_page ) ) {
+	// Webhook IPN calls which are not going through admin-ajax can be detected with pmpro_doing_webhook()
+	if ( ! $is_on_cancel_page && ( ! is_admin() || $is_on_profile_page ) && ! pmpro_doing_webhook() ) {
 		return $level;
 	}
 

--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -44,7 +44,7 @@ function pmproconpd_pmpro_change_level( $level, $user_id, $old_level_status, $ca
 	}
 
 	$is_on_cancel_page = is_page( $pmpro_pages['cancel'] );
-	$is_on_profile_page = is_admin() && ( ! empty( $_REQUEST['from'] && 'profile' === $_REQUEST['from'] ) );
+	$is_on_profile_page = is_admin() && ( ! empty( $_REQUEST['from'] ) && 'profile' === $_REQUEST['from'] );
 
 	// Bypass if not on cancellation page or a non-profile admin page.
 	// Webhook IPN calls that go through admin-ajax are non-profile admin pages.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1) I've found this one in my logs `PHP Notice:  Undefined index: from`
This is happening because the `empty` condition is not working well, because of a misplaced bracket.

2) Resolves #35, #38 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
