### PR TITLE
Bypass when we dont know which is the level being cancelled

### DIFF
--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -43,6 +43,11 @@ function pmproconpd_pmpro_change_level( $level, $user_id, $old_level_status, $ca
 		return $level;
 	}
 
+	// Bypass if we dont know which level is getting cancelled
+	if ( ! $cancel_level ) {
+		return $level;
+	}
+
 	$is_on_cancel_page = is_page( $pmpro_pages['cancel'] );
 	$is_on_profile_page = is_admin() && ( ! empty( $_REQUEST['from'] && 'profile' === $_REQUEST['from'] ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #33.

### How to test the changes in this Pull Request:

1. Enable some log to check when this update fails: https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/blob/e62e9d5c68dfa3b2540b0066eccf15b6fe5989ba/pmpro-cancel-on-next-payment-date.php#L138
2. Call `pmpro_changeMembershipLevel(0, get_current_user_id(), 'cancelled', NULL)`

After applying the patch, that function will bail as soon as possible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
