### PR TITLE
PayPal Express: No extension if payment failed, skipped or suspended

### DIFF
--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -85,7 +85,7 @@ function pmproconpd_pmpro_change_level( $level, $user_id, $old_level_status, $ca
 		$pmpro_next_payment_timestamp = PMProGateway_stripe::pmpro_next_payment( '', $user_id, 'success' );
 	} elseif ( ! empty( $order ) && 'paypalexpress' === $order->gateway ) {
 		// Check the transaction type.
-		if ( ! empty( $_POST['txn_type'] ) && 'recurring_payment_failed' === $_POST['txn_type'] ) {
+		if ( ! empty( $_POST['txn_type'] ) && ( 'recurring_payment_failed' === $_POST['txn_type'] || 'recurring_payment_skipped' === $_POST['txn_type'] ) ) {
 			// Payment failed, so we're past due. No extension.
 			$pmpro_next_payment_timestamp = false;
 		} else {

--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -85,7 +85,11 @@ function pmproconpd_pmpro_change_level( $level, $user_id, $old_level_status, $ca
 		$pmpro_next_payment_timestamp = PMProGateway_stripe::pmpro_next_payment( '', $user_id, 'success' );
 	} elseif ( ! empty( $order ) && 'paypalexpress' === $order->gateway ) {
 		// Check the transaction type.
-		if ( ! empty( $_POST['txn_type'] ) && ( 'recurring_payment_failed' === $_POST['txn_type'] || 'recurring_payment_skipped' === $_POST['txn_type'] ) ) {
+		if ( ! empty( $_POST['txn_type'] ) && in_array( $_POST['txn_type'], [
+				'recurring_payment_failed',
+				'recurring_payment_skipped',
+				'recurring_payment_suspended_due_to_max_failed_payment'
+			] ) ) {
 			// Payment failed, so we're past due. No extension.
 			$pmpro_next_payment_timestamp = false;
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since the new policy is to immediately cancel when a (recurring) payment is NOT completed, there's no reason to still maintain a glue piece of code to make it work with the "Failed payment limit" addon: https://github.com/strangerstudios/pmpro-failed-payment-limit/pull/12/commits/910e0e1943fd8395de69ba9f10f58c8282be246b

Instead, simply don't extend if the condition is met.
There are 3 cases on which we should immediately cancel:
- 'recurring_payment_failed',
- 'recurring_payment_skipped',
- 'recurring_payment_suspended_due_to_max_failed_payment'

They are described here: https://www.bahjeez.com/recurring-payments-ipns/

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
