### PR TITLE
Change "Cancel" btn to "Cancel auto-renew" when subscription is still active

### DIFF
--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -19,7 +19,7 @@ function pmproconpd_load_text_domain() {
 
 add_action( 'plugins_loaded', 'pmproconpd_load_text_domain' );
 
-function pmproconpd_pmpro_member_action_links( $pmpro_member_action_links ) {
+function pmproconpd_change_cancel_button_text( $pmpro_member_action_links ) {
 	global $current_user;
 
 	// bail if cancel link has been removed by someone else
@@ -53,6 +53,8 @@ function pmproconpd_pmpro_member_action_links( $pmpro_member_action_links ) {
 
 	return $pmpro_member_action_links;
 }
+
+add_filter( 'pmpro_member_action_links', 'pmproconpd_change_cancel_button_text' );
 
 add_filter( 'pmpro_member_action_links', 'pmproconpd_pmpro_member_action_links' );
 

--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -47,7 +47,7 @@ function pmproconpd_change_cancel_button_text( $pmpro_member_action_links ) {
 		$pmpro_member_action_links['cancel'] = sprintf(
 			'<a id="pmpro_actionlink-cancel" href="%s">%s</a>',
 			esc_url( add_query_arg( 'levelstocancel', $level->id, pmpro_url( 'cancel' ) ) ),
-			esc_html__( 'Cancel auto-renew', 'pmpro-cancel-on-next-payment-date' )
+			esc_html__( 'Turn off auto-renew', 'pmpro-cancel-on-next-payment-date' )
 		);
 	}
 

--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -46,9 +46,7 @@ function pmproconpd_pmpro_member_action_links( $pmpro_member_action_links ) {
 	if ( ! empty( $morder->id ) && ! empty( $morder->subscription_transaction_id ) && empty( $morder->enddate ) ) {
 		$pmpro_member_action_links['cancel'] = sprintf(
 			'<a id="pmpro_actionlink-cancel" href="%s">%s</a>',
-			esc_url(
-				add_query_arg( 'levelstocancel', $level->id, pmpro_url( 'cancel' ) )
-			),
+			esc_url( add_query_arg( 'levelstocancel', $level->id, pmpro_url( 'cancel' ) ) ),
 			esc_html__( 'Cancel auto-renew', 'pmpro-cancel-on-next-payment-date' )
 		);
 	}

--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -44,7 +44,13 @@ function pmproconpd_pmpro_member_action_links( $pmpro_member_action_links ) {
 
 	// consider paid recurring orders without an enddate
 	if ( ! empty( $morder->id ) && ! empty( $morder->subscription_transaction_id ) && empty( $morder->enddate ) ) {
-		$pmpro_member_action_links['cancel'] = sprintf( '<a id="pmpro_actionlink-cancel" href="%s">%s</a>', esc_url( add_query_arg( 'levelstocancel', $level->id, pmpro_url( 'cancel' ) ) ), esc_html__( 'Cancel auto-renew', 'pmpro-cancel-on-next-payment-date' ) );
+		$pmpro_member_action_links['cancel'] = sprintf(
+			'<a id="pmpro_actionlink-cancel" href="%s">%s</a>',
+			esc_url(
+				add_query_arg( 'levelstocancel', $level->id, pmpro_url( 'cancel' ) )
+			),
+			esc_html__( 'Cancel auto-renew', 'pmpro-cancel-on-next-payment-date' )
+		);
 	}
 
 	return $pmpro_member_action_links;

--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -19,6 +19,39 @@ function pmproconpd_load_text_domain() {
 
 add_action( 'plugins_loaded', 'pmproconpd_load_text_domain' );
 
+function pmproconpd_pmpro_member_action_links( $pmpro_member_action_links ) {
+	global $current_user;
+
+	// bail if cancel link has been removed by someone else
+	if ( ! isset( $pmpro_member_action_links['cancel'] ) ) {
+		return $pmpro_member_action_links;
+	}
+
+	// get current user level
+	$level = pmpro_getMembershipLevelForUser( $current_user->ID );
+
+	// bail if not a recurring level
+	if ( ! pmpro_isLevelRecurring( $level ) ) {
+		return $pmpro_member_action_links;
+	}
+
+	$morder = new MemberOrder();
+	// guess the order which triggered the current user level
+	// TODO use subs table to define if the subs is still active.
+	// atm there's no way to know if a refunded order is for an active sub at gateway.
+	// it's better to assume that only orders in status "success" are still active at gateway.
+	$morder->getLastMemberOrder( $current_user->ID, 'success', $level->id );
+
+	// consider paid recurring orders without an enddate
+	if ( ! empty( $morder->id ) && ! empty( $morder->subscription_transaction_id ) && empty( $morder->enddate ) ) {
+		$pmpro_member_action_links['cancel'] = sprintf( '<a id="pmpro_actionlink-cancel" href="%s">%s</a>', esc_url( add_query_arg( 'levelstocancel', $level->id, pmpro_url( 'cancel' ) ) ), esc_html__( 'Cancel auto-renew', 'pmpro-cancel-on-next-payment-date' ) );
+	}
+
+	return $pmpro_member_action_links;
+}
+
+add_filter( 'pmpro_member_action_links', 'pmproconpd_pmpro_member_action_links' );
+
 /**
  * If the user has a payment coming up, don't cancel.
  * Instead update their expiration date and keep their level.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #16.

### How to test the changes in this Pull Request:

1. Make a recurring level order
2. You should now see "Cancel auto-renew" instead of "Cancel"
3. After you use it, you gonna see "Cancel" to completely cancel the membership

➕  we should provide a snippet to completely remove the cancel button
➕  we should avoid double-clicks on cancel button to cause complete membership cancellation (js hack)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Change "Cancel" btn to "Cancel auto-renew" when subscription is still active
