### PR TITLE
Add support for PayPal Standard (deprecated) and add a missing PPE case to immediately cancel

### DIFF
--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -83,11 +83,20 @@ function pmproconpd_pmpro_change_level( $level, $user_id, $old_level_status, $ca
 		$pmpro_next_payment_timestamp = false;
 	} elseif ( ! empty( $order ) && 'stripe' === $order->gateway ) {
 		$pmpro_next_payment_timestamp = PMProGateway_stripe::pmpro_next_payment( '', $user_id, 'success' );
+	} elseif ( ! empty( $order ) && 'paypalstandard' === $order->gateway ) {
+		if ( ! empty( $_POST['txn_type'] ) && 'subscr_failed' === $_POST['txn_type'] ) {
+			// Payment failed, so we're past due. No extension.
+			$pmpro_next_payment_timestamp = false;
+		} else {
+			// Use the built in PMPro function to guess next payment date.
+			$pmpro_next_payment_timestamp = pmpro_next_payment( $user_id );
+		}
 	} elseif ( ! empty( $order ) && 'paypalexpress' === $order->gateway ) {
 		// Check the transaction type.
 		if ( ! empty( $_POST['txn_type'] ) && in_array( $_POST['txn_type'], [
 				'recurring_payment_failed',
 				'recurring_payment_skipped',
+				'recurring_payment_suspended',
 				'recurring_payment_suspended_due_to_max_failed_payment'
 			] ) ) {
 			// Payment failed, so we're past due. No extension.


### PR DESCRIPTION
Since PayPal Standard was not considered, CONPD was cancelling with an expire date in the future on IPN subscr_failed.
This was wrong, because it means "a recurring payment failed" and we want to immediately cancel.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
