### PR TITLE
Stripe: Immediately cancel if processing a charge.failed request

### DIFF
--- a/pmpro-cancel-on-next-payment-date.php
+++ b/pmpro-cancel-on-next-payment-date.php
@@ -82,7 +82,13 @@ function pmproconpd_pmpro_change_level( $level, $user_id, $old_level_status, $ca
 		// Level already has an end date. Set to false so we really cancel.
 		$pmpro_next_payment_timestamp = false;
 	} elseif ( ! empty( $order ) && 'stripe' === $order->gateway ) {
-		$pmpro_next_payment_timestamp = PMProGateway_stripe::pmpro_next_payment( '', $user_id, 'success' );
+		global $pmpro_stripe_event;
+		if ( 'charge.failed' === $pmpro_stripe_event->type ) {
+			// Payment failed, so we're past due. No extension.
+			$pmpro_next_payment_timestamp = false;
+		} else {
+			$pmpro_next_payment_timestamp = PMProGateway_stripe::pmpro_next_payment( '', $user_id, 'success' );
+		}
 	} elseif ( ! empty( $order ) && 'paypalexpress' === $order->gateway ) {
 		// Check the transaction type.
 		if ( ! empty( $_POST['txn_type'] ) && in_array( $_POST['txn_type'], [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-cancel-on-next-payment-date/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We do want Stripe to immediately cancel on a charge.failed request, which means that it's impossible to renew the membership.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
